### PR TITLE
[BUGFIX] Fix custom variable tracking in async API

### DIFF
--- a/Classes/UserFunc/Footer.php
+++ b/Classes/UserFunc/Footer.php
@@ -366,7 +366,12 @@ class tx_Piwik_UserFunc_Footer {
 
 			// The necessary javascript code.
 			$arguments = trim(json_encode(array($i, $name, $value, $scope)), "[]");
-			$javaScript .= 'piwikTracker.setCustomVariable(' . $arguments . ')' . "\n";
+
+			if ($this->useAsyncTrackingApi) {
+				$javaScript .= '_paq.push(["setCustomVariable", ' . $arguments . ']);' . "\n";
+			} else {
+				$javaScript .= 'piwikTracker.setCustomVariable(' . $arguments . ');' . "\n";
+			}
 
 			// For use in the noscript area.
 			$this->piwikTracker->setCustomVariable($i, $name, $value, $scope);


### PR DESCRIPTION
When the asynchronous tracking API is enabled, the generated
JavaScript code for tracking custom variables is now rendered
with _paq.push() to prevent JavaScript errors.