### PR TITLE
Use correct method to inject document title into JS code.

### DIFF
--- a/Classes/UserFunc/Footer.php
+++ b/Classes/UserFunc/Footer.php
@@ -112,7 +112,7 @@ class tx_Piwik_UserFunc_Footer {
 		$trackingCode .= $this->getLinkTrackingTimer();
 		$trackingCode .= $this->getPiwikSetDownloadExtensions();
 		$trackingCode .= $this->getPiwikAddDownloadExtensions();
-		$trackingCode .= $this->getPiwikActionName();
+		$trackingCode .= $this->getDocumentTitleJS();
 		$trackingCode .= $this->getPiwikTrackGoal();
 		$trackingCode .= $this->getPiwikSetIgnoreClasses();
 		$trackingCode .= $this->getPiwikSetDownloadClasses();


### PR DESCRIPTION
The `getPiwikActionName()` method only returns the name, without the
accompanying JS wrapper code, resulting in JS errors and no tracking.