### PR TITLE
[FEATURE] Use current page title in tracking image URL

### DIFF
--- a/Classes/UserFunc/Footer.php
+++ b/Classes/UserFunc/Footer.php
@@ -133,7 +133,8 @@ class tx_Piwik_UserFunc_Footer {
 		if (strlen($this->piwikOptions['trackGoal'])) {
 			$template = str_replace('###TRACKING_IMAGE_URL###', htmlentities($this->piwikTracker->getUrlTrackGoal($this->piwikOptions['trackGoal'])), $template);
 		} else {
-			$template = str_replace('###TRACKING_IMAGE_URL###', htmlentities($this->piwikTracker->getUrlTrackPageView()), $template);
+			$currentPageTitle = $this->getCurrentPageTitle();
+			$template = str_replace('###TRACKING_IMAGE_URL###', htmlentities($this->piwikTracker->getUrlTrackPageView($currentPageTitle)), $template);
 		}
 
 		if (isset($this->piwikOptions['includeJavaScript']) && !(bool)$this->piwikOptions['includeJavaScript']) {
@@ -150,6 +151,25 @@ class tx_Piwik_UserFunc_Footer {
 	 */
 	function is_backend() {
 		return false;
+	}
+
+	/**
+	 * Returns the page title set in the TSFE page renderer.
+	 *
+	 * @return string
+	 */
+	protected function getCurrentPageTitle() {
+		$tsfe = $this->getTypoScriptFrontendController();
+		if (!$tsfe) {
+			return '';
+		}
+
+		$pageRenderer = $tsfe->getPageRenderer();
+		if (!$pageRenderer) {
+			return '';
+		}
+
+		return $pageRenderer->getTitle();
 	}
 
 	/**
@@ -410,6 +430,13 @@ class tx_Piwik_UserFunc_Footer {
 	}
 
 	/**
+	 * @return \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController
+	 */
+	protected function getTypoScriptFrontendController() {
+		return $GLOBALS['TSFE'];
+	}
+
+	/**
 	 * Creates a new instance of the piwik tracker and
 	 * initializes some variables by using the TYPO3 API
 	 *
@@ -427,7 +454,6 @@ class tx_Piwik_UserFunc_Footer {
 		$this->piwikTracker->setBrowserLanguage(\TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv('HTTP_ACCEPT_LANGUAGE'));
 		$this->piwikTracker->setUserAgent(\TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv('HTTP_USER_AGENT'));
 	}
-
 }
 
 if (defined("TYPO3_MODE") && $TYPO3_CONF_VARS[TYPO3_MODE]["XCLASS"]["ext/piwik/class.tx_piwik.php"]) {


### PR DESCRIPTION
The page title in the current page renderer instance is
now passed to the getUrlTrackPageView() method of the
Piwik PHP tracking API.